### PR TITLE
Replace boolean type with bool in examples

### DIFF
--- a/examples/explore/R03_Disco_Bot/R03_Disco_Bot.ino
+++ b/examples/explore/R03_Disco_Bot/R03_Disco_Bot.ino
@@ -105,7 +105,7 @@ void runScript() {
 }
 
 // instead of delay, use this timer
-boolean waiting() {
+bool waiting() {
   if (millis() - waitFrom >= waitTime) {
     return false;
   } else {
@@ -156,7 +156,7 @@ void setInterface() {
 }
 
 // display the next song
-void select(int seq, boolean onOff) {
+void select(int seq, bool onOff) {
   if (onOff) { //select
     Robot.stroke(0, 0, 0);
     Robot.text(musics[seq], 0, 0);

--- a/examples/explore/R07_Runaway_Robot/R07_Runaway_Robot.ino
+++ b/examples/explore/R07_Runaway_Robot/R07_Runaway_Robot.ino
@@ -60,7 +60,7 @@ float getDistance() {
 }
 
 // make a happy or sad face
-void setFace(boolean onOff) {
+void setFace(bool onOff) {
   if (onOff) {
     // if true show a happy face
     Robot.background(0, 0, 255);

--- a/examples/explore/R08_Remote_Control/R08_Remote_Control.ino
+++ b/examples/explore/R08_Remote_Control/R08_Remote_Control.ino
@@ -36,7 +36,7 @@
 #define IR_CODE_TURN_RIGHT 284127885
 #define IR_CODE_CONTINUE -1
 
-boolean isActing = false; //If the robot is executing command from remote
+bool isActing = false; //If the robot is executing command from remote
 long timer;
 const long TIME_OUT = 150;
 


### PR DESCRIPTION
Replace boolean type with bool in examples

This is part of a move to encourage use of the standard bool type over Arduino's non-standard boolean type alias.

As approved by cmaglie: https://github.com/arduino/Arduino/issues/6657#issuecomment-355597633